### PR TITLE
fix: use lowercase 'bearer' for Codecov API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,22 @@ A Model Context Protocol (MCP) server that provides tools for querying Codecov c
 - **Commit coverage**: Retrieve coverage statistics for individual commits
 - **Repository coverage**: Get overall coverage metrics for repositories
 - **Configurable URL**: Point to any Codecov instance (codecov.io or self-hosted)
-- **Token authentication**: Optional token support for private repositories
+- **Token authentication**: API token support for accessing coverage data
+
+## Token Types
+
+**Important**: Codecov has two different types of tokens:
+
+- **Upload Token**: Used for pushing coverage reports TO Codecov during CI/CD. Found on your repository's Settings → General page.
+- **API Token**: Used for reading coverage data FROM Codecov via the API. Created in your Codecov Settings → Access tab.
+
+This MCP server requires an **API token**, not an upload token. To create an API token:
+
+1. Go to your Codecov instance (e.g., `https://codecov.io` or your self-hosted URL)
+2. Click on your avatar in the top right → Settings
+3. Navigate to the "Access" tab
+4. Click "Generate Token" and name it (e.g., "MCP Server API Access")
+5. Copy the token value and use it in your configuration
 
 ## Installation
 
@@ -159,6 +174,7 @@ codecov: node /path/to/codecov-mcp/dist/index.js - ✓ Connected
 **1. 401 Unauthorized Error**
 
 If you get a `401 Unauthorized` error when using the tools:
+- **Check token type**: Ensure you're using an **API token** (from Settings → Access), not an upload token
 - Ensure `CODECOV_TOKEN` is set in the MCP server's `env` section
 - Verify the token is valid and has access to the repository
 - For self-hosted instances, confirm you're using the correct `CODECOV_BASE_URL`

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ class CodecovClient {
     };
 
     if (this.token) {
-      headers["Authorization"] = `Bearer ${this.token}`;
+      headers["Authorization"] = `bearer ${this.token}`;
     }
 
     const response = await fetch(url, { headers });


### PR DESCRIPTION
## Summary

This PR fixes authentication issues with the Codecov MCP server by correcting the Authorization header format and clarifying token type requirements.

### Issues Fixed

**Problem 1: Incorrect Authorization Header Case**
- Code was using `Authorization: Bearer ${token}` (capital B)
- Codecov API requires `Authorization: bearer ${token}` (lowercase b)
- This caused 401 Unauthorized errors even with valid tokens

**Problem 2: Token Type Confusion**
- Documentation didn't distinguish between upload tokens and API tokens
- Upload tokens (for pushing coverage in CI/CD) don't work with the API
- Users were trying to use upload tokens instead of API tokens

### Changes Made

#### Code Fix (`src/index.ts`)
```diff
- headers["Authorization"] = `Bearer ${this.token}`;
+ headers["Authorization"] = `bearer ${this.token}`;
```

#### Documentation Improvements (`README.md`)
- ✅ Added "Token Types" section explaining the two different token types
- ✅ Provided step-by-step instructions for creating an API token
- ✅ Updated troubleshooting section to check token type first
- ✅ Clarified that API tokens (not upload tokens) are required

### Testing

Tested successfully with self-hosted Codecov instance at `https://codecov.egyrllc.com`:

**Before fixes:**
```
Error: Codecov API error: 401 Unauthorized
```

**After fixes:**
```json
{
  "name": "errandwiz",
  "coverage": 47.29,
  "files": 774,
  "lines": 54881
}
```

### References

- [Codecov API Documentation](https://docs.codecov.com/reference/overview)
- [Getting Started with Codecov API v2](https://about.codecov.io/blog/getting-started-with-the-codecov-api-v2/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)