### PR TITLE
ci: enforce Codecov upload success in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,12 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
-        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           flags: unittests
           name: codecov-mcp-${{ matrix.node-version }}
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true
 
       - name: Archive coverage reports


### PR DESCRIPTION
## Description
This PR enforces Codecov upload success in the CI workflow by removing the error suppression settings that allowed uploads to fail silently.

## Changes Made
- Removed `continue-on-error: true` from Codecov upload step
- Changed `fail_ci_if_error: false` to `fail_ci_if_error: true`

## Impact
- Codecov upload failures will now cause the CI workflow to fail
- Coverage issues will be immediately visible in PR checks
- Ensures coverage reporting is working correctly before merging

## Testing
- The workflow will be tested when this PR triggers the CI
- Successful coverage upload will allow the workflow to pass
- Failed coverage upload will fail the workflow as expected

Fixes #6