### PR TITLE
docs: add Codecov coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Server for Codecov
 
+[![codecov](https://codecov.io/gh/egulatee/mcp-server-codecov/branch/main/graph/badge.svg)](https://codecov.io/gh/egulatee/mcp-server-codecov)
+
 A Model Context Protocol (MCP) server that provides tools for querying Codecov coverage data. Supports both codecov.io and self-hosted Codecov instances with configurable URL endpoints.
 
 ## Features


### PR DESCRIPTION
## Description
This PR adds a Codecov coverage badge to the README, providing immediate visibility into the project's test coverage status on the repository homepage.

## Changes Made
- Added Codecov badge markdown to README.md after the main title
- Badge displays overall coverage percentage for the main branch
- Badge is clickable and links to the full Codecov coverage report

## Badge Details
- **Type**: Static badge link (auto-updates when coverage changes)
- **Location**: Top of README.md, standard badge placement
- **Display**: Shows overall coverage percentage
- **Link**: Points to https://codecov.io/gh/egulatee/mcp-server-codecov

## How It Works
- Codecov automatically generates and updates the badge
- No workflow modifications needed
- Badge updates dynamically when coverage reports are uploaded
- Shows main branch coverage status

## Preview
```markdown
[![codecov](https://codecov.io/gh/egulatee/mcp-server-codecov/branch/main/graph/badge.svg)](https://codecov.io/gh/egulatee/mcp-server-codecov)
```

Fixes #8