### PR TITLE
docs: add documentation badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # MCP Server for Codecov
 
 [![codecov](https://codecov.io/gh/egulatee/mcp-server-codecov/branch/main/graph/badge.svg)](https://codecov.io/gh/egulatee/mcp-server-codecov)
+![Test and Coverage](https://github.com/egulatee/mcp-server-codecov/workflows/Test%20and%20Coverage/badge.svg)
+![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
+![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)
+![TypeScript](https://img.shields.io/badge/TypeScript-5.7+-blue.svg)
+![MCP](https://img.shields.io/badge/MCP-Server-orange.svg)
 
 A Model Context Protocol (MCP) server that provides tools for querying Codecov coverage data. Supports both codecov.io and self-hosted Codecov instances with configurable URL endpoints.
 


### PR DESCRIPTION
## Description
This PR adds five documentation badges to the README to improve visibility into the project's status and requirements.

## Changes Made
✅ Added GitHub Actions CI badge (Test and Coverage workflow)
✅ Added MIT License badge
✅ Added Node.js version badge (≥18.0.0)
✅ Added TypeScript version badge (5.7+)
✅ Added MCP Server badge

## Badge Preview
The badges are positioned after the codecov badge and provide:
- Build/test status visibility
- License information (MIT)
- Node.js compatibility requirements
- TypeScript version information
- MCP server identification

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)