### PR TITLE
Fix GitHub language detection to show TypeScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# TypeScript source files
+*.ts linguist-language=TypeScript
+*.tsx linguist-language=TypeScript
+*.d.ts linguist-language=TypeScript
+
+# Configuration files
+tsconfig.json linguist-language=JSON
+vitest.config.ts linguist-language=TypeScript
+package.json linguist-language=JSON
+
+# Documentation
+*.md linguist-documentation
+
+# Generated/build artifacts
+dist/** linguist-generated=true
+coverage/** linguist-generated=true
+package-lock.json linguist-generated=true
+
+# Vendored dependencies
+node_modules/** linguist-vendored=true


### PR DESCRIPTION
## Summary
Fixes GitHub's language detection to correctly identify this repository as TypeScript instead of JavaScript by adding a `.gitattributes` file with proper Linguist configuration.

## Changes
- Created `.gitattributes` file with comprehensive Linguist directives
- Mark all TypeScript files (`.ts`, `.tsx`, `.d.ts`) as TypeScript language
- Exclude generated files (`dist/`, `coverage/`, `package-lock.json`) from language stats
- Mark `node_modules/` as vendored dependencies (GitHub best practice)
- Classify documentation files (`.md`) appropriately

## Improvements over original proposal
The implementation includes additional enhancements beyond the issue specification:
- Added `node_modules/** linguist-vendored=true` to exclude dependencies from language statistics
- Added `package-lock.json linguist-generated=true` for auto-generated files
- Added `*.md linguist-documentation` to properly categorize documentation
- Better organization with grouped related patterns

## Test plan
- [x] Created `.gitattributes` file with TypeScript Linguist configuration
- [x] Configured exclusions for generated files (dist, coverage)
- [x] Added vendored marking for node_modules
- [ ] Verify GitHub language bar shows TypeScript after merge to main
- [ ] Confirm language statistics are accurate in repository insights

## Related
Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)