### PR TITLE
Fix TypeScript language detection for files with shebangs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
 # TypeScript source files
-*.ts linguist-language=TypeScript
-*.tsx linguist-language=TypeScript
-*.d.ts linguist-language=TypeScript
+*.ts linguist-language=TypeScript linguist-detectable=true
+*.tsx linguist-language=TypeScript linguist-detectable=true
+*.d.ts linguist-language=TypeScript linguist-detectable=true
+src/** linguist-language=TypeScript linguist-detectable=true
 
 # Configuration files
 tsconfig.json linguist-language=JSON


### PR DESCRIPTION
## Summary
Fixes GitHub's JavaScript language detection (21.4%) by adding stronger linguist overrides for TypeScript files containing Node.js shebangs.

## Root Cause
The file `src/index.ts` has a `#!/usr/bin/env node` shebang on line 1, which caused GitHub Linguist to misdetect it as JavaScript instead of TypeScript, resulting in 21.4% JavaScript showing in the language statistics.

## Solution
Enhanced the `.gitattributes` file with:
- Added `linguist-detectable=true` to all TypeScript file patterns (`*.ts`, `*.tsx`, `*.d.ts`)
- Added explicit override: `src/** linguist-language=TypeScript linguist-detectable=true`

This forces GitHub Linguist to treat all TypeScript files as TypeScript, even when they contain shebangs.

## Changes
```diff
# TypeScript source files
-*.ts linguist-language=TypeScript
-*.tsx linguist-language=TypeScript
-*.d.ts linguist-language=TypeScript
+*.ts linguist-language=TypeScript linguist-detectable=true
+*.tsx linguist-language=TypeScript linguist-detectable=true
+*.d.ts linguist-language=TypeScript linguist-detectable=true
+src/** linguist-language=TypeScript linguist-detectable=true
```

## Expected Impact
After merging to main, GitHub should re-analyze and show:
- TypeScript: ~100%
- JavaScript: 0%

## Note
The shebang `#!/usr/bin/env node` is necessary in the source file because TypeScript preserves it during compilation to `dist/index.js`, which is the actual executable.

## Related
Fixes #13 (follow-up to PR #15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)