### PR TITLE
fix: resolve shellcheck warnings in milestone workflow scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,16 +78,16 @@ jobs:
           echo "Found milestone: #$MILESTONE_NUMBER"
 
           # Close the milestone
-          gh api \
+          if gh api \
             --method PATCH \
-            /repos/${{ github.repository }}/milestones/$MILESTONE_NUMBER \
+            /repos/${{ github.repository }}/milestones/"$MILESTONE_NUMBER" \
             -f state=closed \
-            2>/dev/null && {
+            2>/dev/null; then
             echo "✅ Closed milestone #$MILESTONE_NUMBER ($MILESTONE_TITLE)"
-          } || {
+          else
             echo "⚠ Failed to close milestone #$MILESTONE_NUMBER"
             exit 1
-          }
+          fi
 
           # Add to workflow summary
           MILESTONE_URL="https://github.com/${{ github.repository }}/milestone/$MILESTONE_NUMBER?closed=1"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -120,7 +120,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           MILESTONE_NUMBER="${{ steps.milestone.outputs.milestone_number }}"
-          VERSION_TAG="${{ steps.version.outputs.version_tag }}"
 
           echo "Finding PRs merged since last release..."
 
@@ -137,7 +136,7 @@ jobs:
           fi
 
           # Extract PR numbers from merge commits
-          PR_NUMBERS=$(git log --oneline --merges --format="%s" $COMMIT_RANGE \
+          PR_NUMBERS=$(git log --oneline --merges --format="%s" "$COMMIT_RANGE" \
             | grep -oE "Merge pull request #[0-9]+" \
             | grep -oE "[0-9]+" \
             | sort -u)
@@ -147,7 +146,7 @@ jobs:
             exit 0
           fi
 
-          echo "Found PRs to link: $(echo $PR_NUMBERS | tr '\n' ' ')"
+          echo "Found PRs to link: $(echo "$PR_NUMBERS" | tr '\n' ' ')"
 
           # Link each PR to the milestone
           PR_COUNT=0
@@ -155,16 +154,16 @@ jobs:
             echo "Linking PR #$PR_NUMBER to milestone #$MILESTONE_NUMBER..."
 
             # Update PR with milestone
-            gh api \
+            if gh api \
               --method PATCH \
-              /repos/${{ github.repository }}/issues/$PR_NUMBER \
-              -f milestone=$MILESTONE_NUMBER \
-              2>/dev/null && {
+              /repos/${{ github.repository }}/issues/"$PR_NUMBER" \
+              -f milestone="$MILESTONE_NUMBER" \
+              2>/dev/null; then
               echo "✓ Linked PR #$PR_NUMBER"
               PR_COUNT=$((PR_COUNT + 1))
-            } || {
+            else
               echo "⚠ Failed to link PR #$PR_NUMBER (may not exist or already linked)"
-            }
+            fi
           done
 
           echo "✅ Successfully linked $PR_COUNT PRs to milestone"


### PR DESCRIPTION
## Description
This PR resolves shellcheck warnings found in the milestone integration workflows merged in #24.

## Changes Made

### Code Quality Improvements
- ✅ Removed unused `VERSION_TAG` variable from PR linking step
- ✅ Quoted all variables to prevent globbing and word splitting:
  - `$COMMIT_RANGE`, `$PR_NUMBERS`, `$PR_NUMBER`, `$MILESTONE_NUMBER`
- ✅ Replaced `&& { } || { }` pattern with proper `if-then-else` statements
- ✅ Follows shell scripting best practices

### Files Modified
- `.github/workflows/version-bump.yml` - Fixed shellcheck warnings in PR linking logic
- `.github/workflows/release.yml` - Fixed shellcheck warnings in milestone close logic

## Validation
✅ Shellcheck validation passed (0 warnings)
✅ YAML syntax validation passed
✅ All warnings from static analysis resolved

## Related
- Follow-up to #24 (milestone integration feature)
- Addresses #23 (improves code quality)

This ensures the milestone automation workflows follow best practices and pass all static analysis checks.