### PR TITLE
chore: prepare v1.0.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2025-12-20
+
+### Fixed
+- Fixed critical bug where MCP server failed to start when executed via npm bin symlink or npx (#28)
+- Added proper symlink resolution in main module detection using `realpathSync()`
+- Server now correctly starts with all three execution methods:
+  - `npx -y mcp-server-codecov` (standard MCP pattern)
+  - `mcp-server-codecov` (npm bin symlink)
+  - `node /path/to/dist/index.js` (direct execution)
+
+### Changed
+- Updated README.md to use standard `npx` configuration pattern
+- Removed version-specific path workarounds from documentation
+- Configuration now portable across Node.js versions and package managers
+
+## [1.0.0] - 2025-12-19
+
+### Added
+- Initial release of MCP server for Codecov
+- Support for querying Codecov coverage data via MCP protocol
+- Three main tools:
+  - `get_file_coverage`: Get line-by-line coverage for specific files
+  - `get_commit_coverage`: Get coverage data for specific commits
+  - `get_repo_coverage`: Get overall repository coverage statistics
+- Configurable URL support for both codecov.io and self-hosted Codecov instances
+- API token authentication for private repositories
+- Comprehensive test suite with 97%+ code coverage
+- Published to npm registry as `mcp-server-codecov`
+
+[1.0.1]: https://github.com/egulatee/mcp-server-codecov/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/egulatee/mcp-server-codecov/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-codecov",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server for querying Codecov coverage data with configurable URL support",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Prepares v1.0.1 patch release to npm registry. This release contains the critical bug fix for npm bin/npx symlink execution that was merged in #28.

## Changes

### Version Bump
- Updated `package.json` version from `1.0.0` to `1.0.1`

### CHANGELOG
- Created `CHANGELOG.md` following Keep a Changelog format
- Documented v1.0.1 patch release fixes
- Documented v1.0.0 initial release features

## Release Notes (v1.0.1)

### Fixed
- Fixed critical bug where MCP server failed to start via npm bin symlink or npx (#28)
- Added proper symlink resolution using `realpathSync()`
- Server now works with all execution methods:
  - ✅ `npx -y mcp-server-codecov` (standard MCP pattern)
  - ✅ `mcp-server-codecov` (npm bin symlink)
  - ✅ `node /path/to/dist/index.js` (direct execution)

### Changed
- Updated README to use standard `npx` configuration
- Removed version-specific path workarounds
- Configuration now portable across Node versions

## Post-Merge Actions

After this PR merges, the following will be done:
- [ ] Create git tag `v1.0.1`
- [ ] Publish to npm registry
- [ ] Create GitHub release with changelog

## Related Issues

Fixes #30
Includes fix from #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)