### PR TITLE
docs: add LobeHub MCP badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.7+-blue.svg)
 ![MCP](https://img.shields.io/badge/MCP-Server-orange.svg)
+[![MCP Badge](https://lobehub.com/badge/mcp/egulatee-mcp-server-codecov)](https://lobehub.com/mcp/egulatee-mcp-server-codecov)
 
 A Model Context Protocol (MCP) server that provides tools for querying Codecov coverage data. Supports both codecov.io and self-hosted Codecov instances with configurable URL endpoints.
 


### PR DESCRIPTION
## Summary

Adds the LobeHub MCP marketplace badge to the README to increase discoverability and showcase the package's availability in the LobeHub ecosystem.

## Changes Made

- ✅ Added LobeHub MCP badge to README.md badges section
- ✅ Positioned badge after the existing MCP badge for logical grouping

## Badge Details

The badge links directly to our LobeHub listing:
https://lobehub.com/mcp/egulatee-mcp-server-codecov

## Benefits

- **Increases discoverability** through LobeHub MCP marketplace
- **Shows MCP marketplace integration** to users browsing the README
- **Displays quality score** from LobeHub validation
- **Provides direct link** to LobeHub listing for easy access

## Preview

The badge appears as:
[![MCP Badge](https://lobehub.com/badge/mcp/egulatee-mcp-server-codecov)](https://lobehub.com/mcp/egulatee-mcp-server-codecov)

Fixes #38