### PR TITLE
docs: add security policy badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/mcp-server-codecov.svg)](https://www.npmjs.com/package/mcp-server-codecov)
 [![codecov](https://codecov.io/gh/egulatee/mcp-server-codecov/branch/main/graph/badge.svg)](https://codecov.io/gh/egulatee/mcp-server-codecov)
 ![Test and Coverage](https://github.com/egulatee/mcp-server-codecov/workflows/Test%20and%20Coverage/badge.svg)
+[![Security Policy](https://img.shields.io/badge/Security-Policy-blue.svg)](https://github.com/egulatee/mcp-server-codecov/security/policy)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.7+-blue.svg)


### PR DESCRIPTION
## Summary
Added security policy badge to README to improve visibility of security practices.

## Changes
- Added Security Policy badge linking to `/security/policy`
- Badge positioned after test coverage badge in badge row

## Benefits
- Improves discoverability of security reporting procedures
- Shows commitment to security best practices
- Provides quick access to SECURITY.md for users

🤖 Generated with [Claude Code](https://claude.com/claude-code)