### PR TITLE
security: add explicit permissions to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      actions: write
+
     strategy:
       matrix:
         node-version: [20.x, 22.x]


### PR DESCRIPTION
## Summary

Resolves GitHub code scanning alert #2 by adding explicit permissions block to the test workflow following the principle of least privilege.

## Changes

- Added explicit `permissions` block to the test job in `.github/workflows/test.yml`
- Set `contents: read` for repository checkout operations
- Set `actions: write` for artifact upload operations

## Security Impact

This change restricts the scope of the `GITHUB_TOKEN` and improves the security posture of the workflow by:
- Preventing unnecessary write access to repository contents
- Limiting token permissions to only what's required for the job
- Following GitHub's security best practices

## Code Scanning Alert Details

- **Alert**: #2 - Workflow does not contain permissions
- **Severity**: Medium (Security)
- **Rule**: actions/missing-workflow-permissions
- **Location**: `.github/workflows/test.yml:11-58`

## Testing

- [x] Workflow syntax validated
- [x] Permissions limited to minimum required scope
- [ ] Will verify workflow runs successfully after merge

## References

- [GitHub Docs: Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs)
- [Code Scanning Alert #2](https://github.com/egulatee/mcp-server-codecov/security/code-scanning/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)