### PR TITLE
docs: add blog post link to README for referral traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 ![MCP](https://img.shields.io/badge/MCP-Server-orange.svg)
 [![MCP Badge](https://lobehub.com/badge/mcp/egulatee-mcp-server-codecov)](https://lobehub.com/mcp/egulatee-mcp-server-codecov)
 
-A Model Context Protocol (MCP) server that provides tools for querying Codecov coverage data. Built with [AI-augmented development](https://www.aiaugmentedsoftwaredevelopment.com/). Supports both codecov.io and self-hosted Codecov instances with configurable URL endpoints.
+A Model Context Protocol (MCP) server that provides tools for querying Codecov coverage data. Supports both codecov.io and self-hosted Codecov instances with configurable URL endpoints.
 
 📦 **Published on npm:** [mcp-server-codecov](https://www.npmjs.com/package/mcp-server-codecov)
 
-> **📖 Learn More**: Read about [building this MCP server with AI in just 2 hours](https://blog.aiaugmentedsoftwaredevelopment.com/posts/building-codecov-mcp-server-in-2-hours/) on our blog about [AI-augmented software development](https://www.aiaugmentedsoftwaredevelopment.com/).
+> **📖 Learn More**: Read about [building this MCP server with AI in just 2 hours](https://blog.aiaugmentedsoftwaredevelopment.com/posts/building-codecov-mcp-server-in-2-hours/).
 
 ## Quick Start (Claude Code)
 
@@ -318,10 +318,9 @@ This server uses Codecov's API v2. The API endpoints follow this pattern:
 
 Currently supports GitHub repositories (`gh`). Support for other providers (GitLab, Bitbucket) can be added by modifying the API paths.
 
-## Resources & Community
+## Resources
 
 - 📝 [Building the Codecov MCP Server in 2 Hours](https://blog.aiaugmentedsoftwaredevelopment.com/posts/building-codecov-mcp-server-in-2-hours/) - A detailed walkthrough of developing this server using AI-augmented development techniques
-- 🌐 [AI Augmented Software Development](https://www.aiaugmentedsoftwaredevelopment.com/) - Explore more about building software with AI assistance
 
 ## License
 


### PR DESCRIPTION
## Summary
This PR adds a link to the blog post about building this MCP server to drive referral traffic and provide additional context for users. This supersedes #84 with a more focused approach based on understanding that GitHub README links provide referral traffic value rather than traditional SEO backlink value.

## Changes Made
- ✅ Removed website links from README (intro description and Resources section)
- ✅ Kept focused blog post link in callout after intro
- ✅ Simplified Resources section to only include blog post
- ✅ Cleaner, more focused approach

## Rationale
After discussion about SEO value, we determined that:
- GitHub README links are typically `nofollow` (don't pass PageRank)
- The real value is **referral traffic** from developers discovering the project
- A single, focused link to the blog post is more effective than multiple links
- The blog post provides excellent context about the development story

## Test Plan
- [x] Verified blog post link is working correctly
- [x] Confirmed markdown formatting renders properly
- [x] Checked that removal of website links maintains clean document flow

Fixes #86
Supersedes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)