### PR TITLE
feat: rename npm package to @egulatee/mcp-codecov

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Process Guide
 
-This comprehensive guide covers the complete release process for `mcp-server-codecov`, including standard procedures, troubleshooting, rollback procedures, and best practices.
+This comprehensive guide covers the complete release process for `@egulatee/mcp-codecov`, including standard procedures, troubleshooting, rollback procedures, and best practices.
 
 ## Table of Contents
 
@@ -23,7 +23,7 @@ Before creating any release, ensure you have the following configured:
 
 ### 1. npm Authentication
 
-You must have an npm account with publish permissions for `mcp-server-codecov`.
+You must have an npm account with publish permissions for `@egulatee/mcp-codecov`.
 
 ```bash
 # Test if you're logged in
@@ -294,17 +294,17 @@ Run through this checklist before pushing a version tag:
 npm pack
 
 # Inspect tarball contents
-tar -tzf mcp-server-codecov-*.tgz
+tar -tzf egulatee-mcp-codecov-*.tgz
 
 # Test installation from local tarball
-npm install -g ./mcp-server-codecov-*.tgz
+npm install -g ./egulatee-mcp-codecov-*.tgz
 
 # Verify installed package works
-mcp-server-codecov --help
+mcp-codecov --help
 
 # Clean up
-npm uninstall -g mcp-server-codecov
-rm mcp-server-codecov-*.tgz
+npm uninstall -g @egulatee/mcp-codecov
+rm egulatee-mcp-codecov-*.tgz
 ```
 
 **Test prepublishOnly Script:**
@@ -326,7 +326,7 @@ ls -la dist/
 
 ```bash
 # Check current version
-npm version --json | jq .mcp-server-codecov
+npm version --json | jq .@egulatee/mcp-codecov
 
 # Preview version bump (doesn't actually change it)
 npm version patch --dry-run
@@ -422,7 +422,7 @@ gh secret list | grep NPM_TOKEN
 
 3. **Verify token permissions:**
    - Token must have "Automation" type
-   - Must have publish permissions for mcp-server-codecov
+   - Must have publish permissions for @egulatee/mcp-codecov
 
 ### Issue 3: npm Publish Fails (Version Already Exists)
 
@@ -435,10 +435,10 @@ npm error You cannot publish over the previously published versions: 1.0.2
 
 ```bash
 # Check published versions
-npm view mcp-server-codecov versions
+npm view @egulatee/mcp-codecov versions
 
 # Check if version already exists
-npm view mcp-server-codecov@1.0.2 version
+npm view @egulatee/mcp-codecov@1.0.2 version
 ```
 
 **Solutions:**
@@ -499,7 +499,7 @@ gh release list
 ```
 npm error code ELIFECYCLE
 npm error errno 1
-npm error mcp-server-codecov@1.0.2 prepublishOnly: `npm test && npm run build`
+npm error @egulatee/mcp-codecov@1.0.2 prepublishOnly: `npm test && npm run build`
 ```
 
 **Diagnosis:**
@@ -544,7 +544,7 @@ npm test -- src/__tests__/index.test.ts
 **Symptoms:**
 ```
 npm error code ELIFECYCLE
-npm error mcp-server-codecov@1.0.2 build: `tsc`
+npm error @egulatee/mcp-codecov@1.0.2 build: `tsc`
 npm error Exit status 2
 ```
 
@@ -624,13 +624,13 @@ npm error You do not have permission to publish
 
 1. **Verify npm account** has publish permissions:
    ```bash
-   npm owner ls mcp-server-codecov
+   npm owner ls @egulatee/mcp-codecov
    # Your username should be listed
    ```
 
 2. **Add yourself as owner** (if needed):
    ```bash
-   npm owner add <your-username> mcp-server-codecov
+   npm owner add <your-username> @egulatee/mcp-codecov
    ```
 
 3. **Check package scope** (if using scoped package):
@@ -682,10 +682,10 @@ What to do if a release has critical bugs or needs to be reverted.
 
 ```bash
 # EXTREME CAUTION - Only use if absolutely necessary
-npm unpublish mcp-server-codecov@1.0.2
+npm unpublish @egulatee/mcp-codecov@1.0.2
 
 # Verify unpublished
-npm view mcp-server-codecov@1.0.2
+npm view @egulatee/mcp-codecov@1.0.2
 # Should show: npm error 404 Not Found
 ```
 
@@ -693,10 +693,10 @@ npm view mcp-server-codecov@1.0.2
 
 ```bash
 # Mark version as deprecated (preferred over unpublish)
-npm deprecate mcp-server-codecov@1.0.2 "Critical bug - use v1.0.3 instead"
+npm deprecate @egulatee/mcp-codecov@1.0.2 "Critical bug - use v1.0.3 instead"
 
 # Users will see warning when installing:
-# npm WARN deprecated mcp-server-codecov@1.0.2: Critical bug - use v1.0.3 instead
+# npm WARN deprecated @egulatee/mcp-codecov@1.0.2: Critical bug - use v1.0.3 instead
 ```
 
 ### Scenario 3: Delete/Update GitHub Release
@@ -805,7 +805,7 @@ gh release edit v1.0.2 --prerelease
 
 7. **Deprecate buggy version:**
    ```bash
-   npm deprecate mcp-server-codecov@1.0.2 "Critical bug - upgrade to v1.0.3"
+   npm deprecate @egulatee/mcp-codecov@1.0.2 "Critical bug - upgrade to v1.0.3"
    ```
 
 ---
@@ -920,7 +920,7 @@ git push origin v1.0.3
 gh run watch
 
 # Verify npm publish
-npm view mcp-server-codecov@1.0.3
+npm view @egulatee/mcp-codecov@1.0.3
 
 # Verify GitHub release
 gh release view v1.0.3
@@ -939,7 +939,7 @@ gh release view v1.0.3
 - All automated tests pass (`npm test`)
 - Affected functionality manually tested
 - Regression testing of related features
-- Installation test (`npm install -g ./mcp-server-codecov-*.tgz`)
+- Installation test (`npm install -g ./egulatee-mcp-codecov-*.tgz`)
 
 **Acceptable to Skip (for emergency only):**
 - Extended integration testing
@@ -958,51 +958,51 @@ After a release completes, verify everything worked correctly.
 
 ```bash
 # Check latest version
-npm view mcp-server-codecov version
+npm view @egulatee/mcp-codecov version
 
 # Should show: 1.0.2 (your new version)
 
 # View full package info
-npm view mcp-server-codecov
+npm view @egulatee/mcp-codecov
 
 # Check published files
-npm view mcp-server-codecov files
+npm view @egulatee/mcp-codecov files
 ```
 
 **2. Verify Package Metadata:**
 
 ```bash
 # Check package description
-npm view mcp-server-codecov description
+npm view @egulatee/mcp-codecov description
 
 # Verify repository URL
-npm view mcp-server-codecov repository.url
+npm view @egulatee/mcp-codecov repository.url
 
 # Check homepage
-npm view mcp-server-codecov homepage
+npm view @egulatee/mcp-codecov homepage
 ```
 
 **3. Test Installation:**
 
 ```bash
 # Install globally from npm
-npm install -g mcp-server-codecov@1.0.2
+npm install -g @egulatee/mcp-codecov@1.0.2
 
 # Verify command is available
-which mcp-server-codecov
+which mcp-codecov
 
 # Test execution
-mcp-server-codecov --version
+mcp-codecov --version
 
 # Uninstall
-npm uninstall -g mcp-server-codecov
+npm uninstall -g @egulatee/mcp-codecov
 ```
 
 **4. Test with npx:**
 
 ```bash
 # Test standard MCP pattern
-npx -y mcp-server-codecov
+npx -y @egulatee/mcp-codecov
 
 # Should start server without errors
 ```
@@ -1078,10 +1078,10 @@ gh run view <run-id> --log | grep -i warn
 mkdir /tmp/mcp-test && cd /tmp/mcp-test
 
 # Install package
-npm install mcp-server-codecov@1.0.2
+npm install @egulatee/mcp-codecov@1.0.2
 
 # Verify installation
-npx mcp-server-codecov --version
+npx mcp-codecov --version
 
 # Clean up
 cd ~ && rm -rf /tmp/mcp-test
@@ -1096,7 +1096,7 @@ cd ~ && rm -rf /tmp/mcp-test
   "mcpServers": {
     "codecov-test": {
       "command": "npx",
-      "args": ["-y", "mcp-server-codecov@1.0.2"],
+      "args": ["-y", "@egulatee/mcp-codecov@1.0.2"],
       "env": {
         "CODECOV_BASE_URL": "https://codecov.io"
       }
@@ -1121,7 +1121,7 @@ After each release, check:
 
 - [ ] **npm package published**
   ```bash
-  npm view mcp-server-codecov@1.0.2
+  npm view @egulatee/mcp-codecov@1.0.2
   ```
 
 - [ ] **GitHub release created**
@@ -1146,7 +1146,7 @@ After each release, check:
 
 - [ ] **Package installs correctly**
   ```bash
-  npx -y mcp-server-codecov@1.0.2
+  npx -y @egulatee/mcp-codecov@1.0.2
   ```
 
 - [ ] **README shows latest version**
@@ -1316,9 +1316,9 @@ npm run prepublishOnly
 ```bash
 # Before releasing, test local install
 npm pack
-npm install -g ./mcp-server-codecov-*.tgz
-mcp-server-codecov --version
-npm uninstall -g mcp-server-codecov
+npm install -g ./egulatee-mcp-codecov-*.tgz
+mcp-codecov --version
+npm uninstall -g @egulatee/mcp-codecov
 ```
 
 ### Documentation
@@ -1644,7 +1644,7 @@ Frequently asked questions about the release process.
 
 ```bash
 # Deprecate wrong version
-npm deprecate mcp-server-codecov@1.0.2 "Incorrect release - use v1.0.3"
+npm deprecate @egulatee/mcp-codecov@1.0.2 "Incorrect release - use v1.0.3"
 
 # Release correct version
 npm version patch  # 1.0.3
@@ -1734,9 +1734,9 @@ gh release create v2.0.0-alpha.1 --prerelease --notes "Alpha release for testing
 
 Users install with:
 ```bash
-npm install mcp-server-codecov@alpha
+npm install @egulatee/mcp-codecov@alpha
 # or specific version
-npm install mcp-server-codecov@2.0.0-alpha.1
+npm install @egulatee/mcp-codecov@2.0.0-alpha.1
 ```
 
 ### Q: What if the workflow fails halfway through?
@@ -1801,7 +1801,7 @@ git push origin v1.0.3
 
 **Requirements:**
 - Repository write access (to push tags)
-- npm publish permissions for mcp-server-codecov
+- npm publish permissions for @egulatee/mcp-codecov
 - Access to NPM_TOKEN secret (maintainers only)
 
 **Best practice:**
@@ -1818,7 +1818,7 @@ git push origin v1.0.3
 gh run list --workflow=release.yml --limit 1
 
 # 2. npm package published
-npm view mcp-server-codecov@1.0.2
+npm view @egulatee/mcp-codecov@1.0.2
 
 # 3. GitHub release created
 gh release view v1.0.2
@@ -1827,7 +1827,7 @@ gh release view v1.0.2
 git ls-remote --tags origin | grep v1.0.2
 
 # 5. Package installs correctly
-npx -y mcp-server-codecov@1.0.2
+npx -y @egulatee/mcp-codecov@1.0.2
 ```
 
 All must succeed for a successful release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,8 +154,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed critical bug where MCP server failed to start when executed via npm bin symlink or npx (#28)
 - Added proper symlink resolution in main module detection using `realpathSync()`
 - Server now correctly starts with all three execution methods:
-  - `npx -y mcp-server-codecov` (standard MCP pattern)
-  - `mcp-server-codecov` (npm bin symlink)
+  - `npx -y @egulatee/mcp-codecov` (standard MCP pattern)
+  - `mcp-codecov` (npm bin symlink)
   - `node /path/to/dist/index.js` (direct execution)
 
 ### Changed
@@ -175,7 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable URL support for both codecov.io and self-hosted Codecov instances
 - API token authentication for private repositories
 - Comprehensive test suite with 97%+ code coverage
-- Published to npm registry as `mcp-server-codecov`
+- Published to npm registry as `@egulatee/mcp-codecov`
 
 [1.3.0]: https://github.com/egulatee/mcp-server-codecov/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/egulatee/mcp-server-codecov/compare/v1.1.0...v1.2.1

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,6 @@
 # Publishing Guide
 
-This guide explains how to publish new versions of `mcp-server-codecov` to npm.
+This guide explains how to publish new versions of `@egulatee/mcp-codecov` to npm.
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ npm run test:integration
 
 **Automated via GitHub Actions (Recommended)**:
 
-1. Go to the GitHub repository: https://github.com/egulatee/mcp-server-codecov
+1. Go to the GitHub repository: https://github.com/egulatee/@egulatee/mcp-codecov
 2. Navigate to **Actions** → **Version Bump**
 3. Click **Run workflow**
 4. Select the version bump type:
@@ -77,7 +77,7 @@ The version bump workflow triggers the release workflow, which will automaticall
 
 **Monitor the release workflow**:
 ```
-https://github.com/egulatee/mcp-server-codecov/actions/workflows/release.yml
+https://github.com/egulatee/@egulatee/mcp-codecov/actions/workflows/release.yml
 ```
 
 **Expected workflow duration**: ~40 seconds
@@ -85,8 +85,8 @@ https://github.com/egulatee/mcp-server-codecov/actions/workflows/release.yml
 **Successful publication indicators**:
 - Version bump workflow: ✅ Success
 - Release workflow: ✅ Success
-- npm package updated: `npm view mcp-server-codecov version`
-- GitHub release created: https://github.com/egulatee/mcp-server-codecov/releases
+- npm package updated: `npm view @egulatee/mcp-codecov version`
+- GitHub release created: https://github.com/egulatee/@egulatee/mcp-codecov/releases
 
 **Verify Publication**:
 
@@ -94,19 +94,19 @@ After the workflow completes, verify the package was published:
 
 **Check npm:**
 ```bash
-npm view mcp-server-codecov version
-npm view mcp-server-codecov dist.tarball
+npm view @egulatee/mcp-codecov version
+npm view @egulatee/mcp-codecov dist.tarball
 ```
 
 **Check GitHub Releases:**
 ```
-https://github.com/egulatee/mcp-server-codecov/releases
+https://github.com/egulatee/@egulatee/mcp-codecov/releases
 ```
 
 **Test Installation:**
 ```bash
-npm install -g mcp-server-codecov@latest
-mcp-server-codecov --help 2>&1 | head -5
+npm install -g @egulatee/mcp-codecov@latest
+@egulatee/mcp-codecov --help 2>&1 | head -5
 ```
 
 ## Manual Publishing (Emergency Only)
@@ -170,7 +170,7 @@ npm version prerelease --preid=beta
 # Publish with beta tag
 npm publish --tag beta
 
-# Users install with: npm install mcp-server-codecov@beta
+# Users install with: npm install @egulatee/mcp-codecov@beta
 ```
 
 ## Troubleshooting
@@ -191,7 +191,7 @@ npm error 403 Forbidden - Two-factor authentication or granular access token wit
 1. Create a new Granular Access Token at: https://www.npmjs.com/settings/[USERNAME]/tokens/granular-access-tokens/new
 2. **CRITICAL**: Enable "Bypass two-factor authentication when using this token to publish"
 3. Set permissions: "Packages and scopes" → "Read and write"
-4. Select package: `mcp-server-codecov`
+4. Select package: `@egulatee/mcp-codecov`
 5. Set expiration (max 90 days for granular tokens)
 6. Copy token immediately
 7. Update GitHub secret: `gh secret set NPM_TOKEN`
@@ -227,7 +227,7 @@ git push origin v1.0.0
 **Solutions**:
 - Cannot unpublish after 72 hours
 - Bump to next version instead
-- If within 72 hours: `npm unpublish mcp-server-codecov@1.0.0`
+- If within 72 hours: `npm unpublish @egulatee/mcp-codecov@1.0.0`
 
 ## Security
 
@@ -243,10 +243,10 @@ The `--provenance` flag was removed from the publish workflow because:
 To verify package integrity, users can check:
 ```bash
 # Verify package tarball checksum
-npm view mcp-server-codecov dist.shasum
+npm view @egulatee/mcp-codecov dist.shasum
 
 # Check package integrity
-npm view mcp-server-codecov dist.integrity
+npm view @egulatee/mcp-codecov dist.integrity
 ```
 
 ### Token Management
@@ -265,7 +265,7 @@ npm has deprecated Classic tokens. You **must** use Granular Access Tokens with 
    - **Packages and scopes**:
      - Select "Read and write"
      - Choose "Only select packages and scopes"
-     - Add package: `mcp-server-codecov`
+     - Add package: `@egulatee/mcp-codecov`
    - **🚨 CRITICAL SETTING**:
      - **MUST ENABLE**: "Bypass two-factor authentication when using this token to publish"
      - Without this setting, CI/CD publishing will fail with E403 error
@@ -287,7 +287,7 @@ npm has deprecated Classic tokens. You **must** use Granular Access Tokens with 
 
 **Security Best Practices**:
 - Store as GitHub secret only (never commit)
-- Use minimal scope (only mcp-server-codecov package)
+- Use minimal scope (only @egulatee/mcp-codecov package)
 - Enable bypass 2FA only for CI/CD tokens
 - Monitor npm audit logs for unauthorized publish attempts
 
@@ -295,9 +295,9 @@ npm has deprecated Classic tokens. You **must** use Granular Access Tokens with 
 
 After a successful release:
 
-- [ ] Verify package on npm: `npm view mcp-server-codecov`
+- [ ] Verify package on npm: `npm view @egulatee/mcp-codecov`
 - [ ] Check GitHub release created
-- [ ] Test global installation: `npm install -g mcp-server-codecov`
+- [ ] Test global installation: `npm install -g @egulatee/mcp-codecov`
 - [ ] Update documentation if needed
 - [ ] Announce release (if major version)
 - [ ] Monitor for issues in first 24 hours
@@ -306,7 +306,7 @@ After a successful release:
 
 If you encounter issues publishing:
 
-1. Check [GitHub Actions logs](https://github.com/egulatee/mcp-server-codecov/actions)
-2. Verify [npm package page](https://www.npmjs.com/package/mcp-server-codecov)
-3. Review [GitHub releases](https://github.com/egulatee/mcp-server-codecov/releases)
+1. Check [GitHub Actions logs](https://github.com/egulatee/@egulatee/mcp-codecov/actions)
+2. Verify [npm package page](https://www.npmjs.com/package/@egulatee/mcp-codecov)
+3. Review [GitHub releases](https://github.com/egulatee/@egulatee/mcp-codecov/releases)
 4. Open an issue if automated publishing is broken

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MCP Server for Codecov
 
-[![npm version](https://img.shields.io/npm/v/mcp-server-codecov.svg)](https://www.npmjs.com/package/mcp-server-codecov)
-[![npm downloads](https://img.shields.io/npm/dm/mcp-server-codecov.svg)](https://www.npmjs.com/package/mcp-server-codecov)
+[![npm version](https://img.shields.io/npm/v/@egulatee/mcp-codecov.svg)](https://www.npmjs.com/package/@egulatee/mcp-codecov)
+[![npm downloads](https://img.shields.io/npm/dm/@egulatee/mcp-codecov.svg)](https://www.npmjs.com/package/@egulatee/mcp-codecov)
 [![codecov](https://codecov.io/gh/egulatee/mcp-server-codecov/branch/main/graph/badge.svg)](https://codecov.io/gh/egulatee/mcp-server-codecov)
 ![Test and Coverage](https://github.com/egulatee/mcp-server-codecov/workflows/Test%20and%20Coverage/badge.svg)
 [![Security Policy](https://img.shields.io/badge/Security-Policy-blue.svg)](https://github.com/egulatee/mcp-server-codecov/security/policy)
@@ -9,11 +9,11 @@
 ![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.7+-blue.svg)
 ![MCP](https://img.shields.io/badge/MCP-Server-orange.svg)
-[![MCP Badge](https://lobehub.com/badge/mcp/egulatee-mcp-server-codecov)](https://lobehub.com/mcp/egulatee-mcp-server-codecov)
+[![MCP Badge](https://lobehub.com/badge/mcp/egulatee-mcp-codecov)](https://lobehub.com/mcp/egulatee-mcp-codecov)
 
 A Model Context Protocol (MCP) server that provides tools for querying Codecov coverage data. Supports both codecov.io and self-hosted Codecov instances with configurable URL endpoints.
 
-📦 **Published on npm:** [mcp-server-codecov](https://www.npmjs.com/package/mcp-server-codecov)
+📦 **Published on npm:** [@egulatee/mcp-codecov](https://www.npmjs.com/package/@egulatee/mcp-codecov)
 
 > **📖 Learn More**: Read about [building this MCP server with AI in just 2 hours](https://blog.aiaugmentedsoftwaredevelopment.com/posts/building-codecov-mcp-server-in-2-hours/).
 
@@ -46,7 +46,7 @@ Then reload: `source ~/.zshrc`
 claude mcp add --transport stdio codecov \
   --env CODECOV_BASE_URL=https://codecov.io \
   --env CODECOV_TOKEN=${CODECOV_TOKEN} \
-  -- npx -y mcp-server-codecov
+  -- npx -y @egulatee/mcp-codecov
 ```
 
 ### 4. Verify installation
@@ -55,7 +55,7 @@ claude mcp add --transport stdio codecov \
 claude mcp get codecov
 ```
 
-Expected output: `codecov: mcp-server-codecov - ✓ Connected`
+Expected output: `codecov: @egulatee/mcp-codecov - ✓ Connected`
 
 **That's it!** You can now use Codecov tools in Claude Code. See [Available Tools](#available-tools) below.
 
@@ -220,7 +220,7 @@ For self-hosted Codecov instances, use your instance URL:
 claude mcp add --transport stdio codecov \
   --env CODECOV_BASE_URL=https://codecov.your-company.com \
   --env CODECOV_TOKEN=${CODECOV_TOKEN} \
-  -- npx -y mcp-server-codecov
+  -- npx -y @egulatee/mcp-codecov
 ```
 
 ### Claude Desktop Setup
@@ -236,7 +236,7 @@ Add to your Claude Desktop configuration file:
   "mcpServers": {
     "codecov": {
       "command": "npx",
-      "args": ["-y", "mcp-server-codecov"],
+      "args": ["-y", "@egulatee/mcp-codecov"],
       "env": {
         "CODECOV_BASE_URL": "https://codecov.io",
         "CODECOV_TOKEN": "your-codecov-token-here"
@@ -255,7 +255,7 @@ Add to `~/.claude.json`:
   "mcpServers": {
     "codecov": {
       "command": "npx",
-      "args": ["-y", "mcp-server-codecov"],
+      "args": ["-y", "@egulatee/mcp-codecov"],
       "env": {
         "CODECOV_BASE_URL": "https://codecov.io",
         "CODECOV_TOKEN": "${CODECOV_TOKEN}"
@@ -273,20 +273,20 @@ Add to `~/.claude.json`:
 ### Installing from npm Globally
 
 ```bash
-npm install -g mcp-server-codecov
+npm install -g @egulatee/mcp-codecov
 ```
 
 **Benefits:**
 - Simple one-command installation
-- Automatic updates with `npm update -g mcp-server-codecov`
+- Automatic updates with `npm update -g @egulatee/mcp-codecov`
 - No manual build steps required
 - Works across all projects
 
 **Verify installation:**
 ```bash
-npm list -g mcp-server-codecov
-which mcp-server-codecov
-npm view mcp-server-codecov version
+npm list -g @egulatee/mcp-codecov
+which mcp-codecov
+npm view @egulatee/mcp-codecov version
 ```
 
 ### Development Installation (Source)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -11,28 +11,28 @@ Before troubleshooting, verify the package is correctly installed:
 **Check package version:**
 ```bash
 # Check installed version
-npm list -g mcp-server-codecov
+npm list -g @egulatee/mcp-codecov
 
 # Verify command exists
-which mcp-server-codecov
+which mcp-codecov
 
 # View package info on npm
-npm view mcp-server-codecov version
-npm view mcp-server-codecov dist.tarball
+npm view @egulatee/mcp-codecov version
+npm view @egulatee/mcp-codecov dist.tarball
 ```
 
 **Expected output:**
 ```
 /Users/yourname/.npm-global/lib
-└── mcp-server-codecov@1.0.0
+└── @egulatee/mcp-codecov@1.0.0
 
-/Users/yourname/.npm-global/bin/mcp-server-codecov
+/Users/yourname/.npm-global/bin/mcp-codecov
 ```
 
 **Verify package contents:**
 ```bash
 # Check installed files
-ls -la $(npm root -g)/mcp-server-codecov/dist/
+ls -la $(npm root -g)/@egulatee/mcp-codecov/dist/
 
 # Should show:
 # index.js
@@ -44,7 +44,7 @@ ls -la $(npm root -g)/mcp-server-codecov/dist/
 **Test the command:**
 ```bash
 # Should start the MCP server
-mcp-server-codecov
+mcp-codecov
 
 # Expected output:
 # Codecov MCP Server running on stdio
@@ -52,7 +52,7 @@ mcp-server-codecov
 # Token configured: No (or Yes if CODECOV_TOKEN is set)
 ```
 
-### "command not found: mcp-server-codecov"
+### "command not found: mcp-codecov"
 
 After global installation, if the command is not found:
 
@@ -77,13 +77,13 @@ source ~/.zshrc
 
 **Solution 2: Reinstall globally**
 ```bash
-npm uninstall -g mcp-server-codecov
-npm install -g mcp-server-codecov
+npm uninstall -g @egulatee/mcp-codecov
+npm install -g @egulatee/mcp-codecov
 ```
 
 **Solution 3: Use npx (temporary)**
 ```bash
-npx mcp-server-codecov
+npx @egulatee/mcp-codecov
 ```
 
 ### Permission Denied During Install
@@ -103,12 +103,12 @@ echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.zshrc
 source ~/.zshrc
 
 # Reinstall package
-npm install -g mcp-server-codecov
+npm install -g @egulatee/mcp-codecov
 ```
 
 **Solution 2: Use sudo (Not Recommended)**
 ```bash
-sudo npm install -g mcp-server-codecov
+sudo npm install -g @egulatee/mcp-codecov
 ```
 
 ### Package Installation Fails
@@ -130,7 +130,7 @@ npm cache verify
 npm cache clean --force
 
 # Try different registry
-npm install -g mcp-server-codecov --registry=https://registry.npmjs.org
+npm install -g @egulatee/mcp-codecov --registry=https://registry.npmjs.org
 
 # Update npm
 npm install -g npm@latest
@@ -159,7 +159,7 @@ Update your configuration:
 {
   "mcpServers": {
     "codecov": {
-      "command": "mcp-server-codecov",
+      "command": "mcp-codecov",
       "env": {
         "CODECOV_BASE_URL": "https://codecov.io"
       }
@@ -215,7 +215,7 @@ source ~/.zshrc
 {
   "mcpServers": {
     "codecov": {
-      "command": "mcp-server-codecov",
+      "command": "mcp-codecov",
       "env": {
         "CODECOV_TOKEN": "your-actual-token"
       }
@@ -233,7 +233,7 @@ source ~/.zshrc
 **Diagnosis:**
 ```bash
 # Test the server manually
-mcp-server-codecov
+mcp-codecov
 
 # Should show:
 # Codecov MCP Server running on stdio
@@ -339,7 +339,7 @@ gh api repos/owner/repo/contents/path/to/file.ts
 **Diagnosis:**
 ```bash
 # Test with MCP Inspector
-npx @modelcontextprotocol/inspector mcp-server-codecov
+npx @modelcontextprotocol/inspector @egulatee/mcp-codecov
 
 # Lists available tools:
 # - get_file_coverage
@@ -478,7 +478,7 @@ Enable detailed logging:
 
 ```bash
 # Run server with stdio output visible
-mcp-server-codecov 2>&1 | tee /tmp/mcp-debug.log
+mcp-codecov 2>&1 | tee /tmp/mcp-debug.log
 
 # Check what's being logged
 tail -f /tmp/mcp-debug.log
@@ -488,32 +488,32 @@ tail -f /tmp/mcp-debug.log
 
 ```bash
 # Check what was installed
-npm list -g mcp-server-codecov
+npm list -g @egulatee/mcp-codecov
 
 # Verify dist folder exists
-ls -la $(npm root -g)/mcp-server-codecov/dist/
+ls -la $(npm root -g)/@egulatee/mcp-codecov/dist/
 
 # Check package.json
-cat $(npm root -g)/mcp-server-codecov/package.json
+cat $(npm root -g)/@egulatee/mcp-codecov/package.json
 ```
 
 ### Clean Reinstall
 
 ```bash
 # Complete clean reinstall
-npm uninstall -g mcp-server-codecov
+npm uninstall -g @egulatee/mcp-codecov
 npm cache clean --force
-npm install -g mcp-server-codecov
+npm install -g @egulatee/mcp-codecov
 
 # Verify
-mcp-server-codecov --help 2>&1 | head -5
+mcp-codecov --help 2>&1 | head -5
 ```
 
 ## Getting Help
 
 If you're still experiencing issues:
 
-1. **Check existing issues**: https://github.com/egulatee/mcp-server-codecov/issues
+1. **Check existing issues**: https://github.com/egulatee/@egulatee/mcp-codecov/issues
 2. **Create a new issue** with:
    - Your operating system
    - Node.js version: `node --version`
@@ -526,11 +526,11 @@ If you're still experiencing issues:
    # System info
    node --version
    npm --version
-   which mcp-server-codecov
-   npm list -g mcp-server-codecov
+   which mcp-codecov
+   npm list -g @egulatee/mcp-codecov
 
    # Test server
-   mcp-server-codecov 2>&1 | head -20
+   mcp-codecov 2>&1 | head -20
    ```
 
 ## Common Patterns
@@ -541,18 +541,18 @@ If nothing works, try this complete reset:
 
 ```bash
 # 1. Uninstall everything
-npm uninstall -g mcp-server-codecov
-rm -rf ~/.npm-global/lib/node_modules/mcp-server-codecov
+npm uninstall -g @egulatee/mcp-codecov
+rm -rf ~/.npm-global/lib/node_modules/@egulatee/mcp-codecov
 
 # 2. Clean npm cache
 npm cache clean --force
 
 # 3. Reinstall
-npm install -g mcp-server-codecov
+npm install -g @egulatee/mcp-codecov
 
 # 4. Verify installation
-which mcp-server-codecov
-mcp-server-codecov 2>&1 | head -5
+which mcp-codecov
+mcp-codecov 2>&1 | head -5
 
 # 5. Update configuration
 # (Edit Claude config files)
@@ -568,8 +568,8 @@ mcp-server-codecov 2>&1 | head -5
 
 Use this checklist to diagnose issues:
 
-- [ ] Server command exists: `which mcp-server-codecov`
-- [ ] Server runs manually: `mcp-server-codecov`
+- [ ] Server command exists: `which mcp-codecov`
+- [ ] Server runs manually: `mcp-codecov`
 - [ ] Environment variables set: `echo $CODECOV_TOKEN`
 - [ ] Configuration file valid: `python3 -m json.tool < ~/.claude.json`
 - [ ] Claude restarted after config changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "mcp-server-codecov",
-  "version": "1.2.0",
+  "name": "@egulatee/mcp-codecov",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp-server-codecov",
-      "version": "1.2.0",
+      "name": "@egulatee/mcp-codecov",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"
       },
       "bin": {
-        "mcp-server-codecov": "dist/index.js"
+        "mcp-codecov": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "mcp-server-codecov",
+  "name": "@egulatee/mcp-codecov",
   "version": "1.3.0",
   "description": "MCP server for querying Codecov coverage data with configurable URL support",
-  "mcpName": "io.github.egulatee/codecov",
+  "mcpName": "@egulatee/codecov",
   "publisher": "egulatee",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     }
   },
   "bin": {
-    "mcp-server-codecov": "dist/index.js"
+    "mcp-codecov": "dist/index.js"
   },
   "files": [
     "dist",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -603,7 +603,7 @@ describe('main', () => {
     // Verify Server was created
     expect(Server).toHaveBeenCalledWith(
       {
-        name: 'mcp-server-codecov',
+        name: '@egulatee/mcp-codecov',
         version: packageJson.version,
       },
       {

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -48,7 +48,7 @@ export function createResourceHandler() {
 ## Installation
 
 \`\`\`bash
-npm install -g mcp-server-codecov
+npm install -g @egulatee/mcp-codecov
 \`\`\`
 
 ## Configuration
@@ -59,7 +59,7 @@ Set environment variables:
 
 ## Basic Usage
 
-1. Configure your MCP client to use \`mcp-server-codecov\`
+1. Configure your MCP client to use \`@egulatee/mcp-codecov\`
 2. Use the available tools:
    - \`get_repo_coverage\`: Get overall repository coverage
    - \`get_commit_coverage\`: Get coverage for specific commit

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ export async function startServer() {
 
   const server = new Server(
     {
-      name: "mcp-server-codecov",
+      name: "@egulatee/mcp-codecov",
       version: getPackageVersion(),
     },
     {


### PR DESCRIPTION
## Summary
Rename the npm package from `mcp-server-codecov` to `@egulatee/mcp-codecov` to follow modern scoped package conventions and align with other MCP server naming patterns.

## Changes Made
- ✅ Updated package.json:
  - `name`: `mcp-server-codecov` → `@egulatee/mcp-codecov`
  - `bin`: `mcp-server-codecov` → `mcp-codecov`
  - `mcpName`: `io.github.egulatee/codecov` → `@egulatee/codecov`
- ✅ Updated documentation (10 files):
  - README.md: npm badges, installation commands, examples
  - CHANGELOG.md: package references
  - PUBLISHING.md: publishing instructions
  - TROUBLESHOOTING.md: troubleshooting commands
  - .github/RELEASE.md: release procedures
- ✅ Updated source code:
  - src/server.ts: server name
  - src/resources.ts: installation instructions
  - src/__tests__/index.test.ts: test expectations
- ✅ Regenerated package-lock.json with new package name
- ✅ All tests passing (80/80)

## Benefits
- Follows scoped package convention used by other MCP servers (e.g., `@modelcontextprotocol/server-*`)
- Cleaner binary name (`mcp-codecov` instead of `mcp-server-codecov`)
- Better namespace management under `@egulatee` scope
- Consistent with community MCP server naming patterns

## Testing
- [x] Build successful: `npm run build`
- [x] All unit tests passing: `npm test` (80/80)
- [x] Package install works: `npm install`
- [x] No TypeScript errors

## Next Steps
After merge, the old package `mcp-server-codecov` should be deprecated on npm with a message pointing to the new package name `@egulatee/mcp-codecov`.

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)