### PR TITLE
feat: publish multi-platform Docker image to ghcr.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+.git
+.github
+coverage
+**/__tests__
+**/*.test.ts
+test/
+docs/
+*.md
+.nvmrc
+vitest.config.ts
+tsconfig.json
+codecov.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,49 @@ jobs:
           body_path: release_notes.md
           draft: false
           prerelease: false
+
+  docker:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/egulatee/mcp-server-codecov
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Docker image**: Official multi-platform Docker image published to `ghcr.io/egulatee/mcp-server-codecov` on every release (#110)
+  - Supports `linux/amd64` and `linux/arm64` (Apple Silicon, AWS Graviton)
+  - Tags: `latest`, major (`2`), minor (`2.1`), patch (`2.1.0`)
+  - No Node.js installation required — run via `docker run`
+  - Non-root user (`node`) for security
+- `Dockerfile` (multi-stage, `node:20-alpine` base)
+- `.dockerignore` to keep build context lean
+- Docker build+push job in `release.yml` (runs after npm publish, uses `GITHUB_TOKEN`)
+
 ## [2.0.0] - 2026-02-13
 
 ### BREAKING CHANGES

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Stage 1 — build
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2 — runtime
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+USER node
+ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 A Model Context Protocol (MCP) server that provides tools for querying Codecov coverage data. Supports both codecov.io and self-hosted Codecov instances with configurable URL endpoints.
 
 📦 **Published on npm:** [@egulatee/mcp-codecov](https://www.npmjs.com/package/@egulatee/mcp-codecov)
+🐳 **Docker image:** [ghcr.io/egulatee/mcp-server-codecov](https://ghcr.io/egulatee/mcp-server-codecov)
 
 > **📖 Learn More**: Read about [building this MCP server with AI in just 2 hours](https://blog.aiaugmentedsoftwaredevelopment.com/posts/building-codecov-mcp-server-in-2-hours/).
 
@@ -268,6 +269,46 @@ Add to `~/.claude.json`:
 - Environment variable expansion is supported using `${VAR}` syntax
 - Variables like `${CODECOV_TOKEN}` will be read from your shell environment
 - The `-y` flag for npx automatically accepts the package installation prompt
+
+### Docker (no Node.js required)
+
+Pull and run the official multi-platform image from GitHub Container Registry:
+
+```bash
+docker run --rm -i \
+  -e CODECOV_TOKEN=your_token \
+  ghcr.io/egulatee/mcp-server-codecov
+```
+
+**Platforms:** `linux/amd64` and `linux/arm64` (Apple Silicon, AWS Graviton)
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "codecov": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "CODECOV_TOKEN=your_token",
+        "ghcr.io/egulatee/mcp-server-codecov"
+      ]
+    }
+  }
+}
+```
+
+**With self-hosted Codecov:**
+
+```bash
+docker run --rm -i \
+  -e CODECOV_TOKEN=your_token \
+  -e CODECOV_BASE_URL=https://codecov.your-company.com \
+  ghcr.io/egulatee/mcp-server-codecov
+```
+
+**Available tags:** `latest`, `2`, `2.1`, `2.1.0` (full semver)
 
 ### Installing from npm Globally
 


### PR DESCRIPTION
## Summary

- Add `Dockerfile` — multi-stage build (`node:20-alpine`), non-root `USER node`, production deps only in runtime stage
- Add `.dockerignore` — excludes tests, docs, `.git`, coverage, config-only files from build context
- Extend `.github/workflows/release.yml` — new `docker` job runs after `release` succeeds; logs into `ghcr.io` via `GITHUB_TOKEN`, builds `linux/amd64` + `linux/arm64`, pushes with semver tags
- Update `README.md` — Docker installation section with CLI and Claude Desktop usage examples
- Update `CHANGELOG.md` — `[Unreleased]` entry documenting the changes

## How it works

On every `v*` tag push:
1. Existing `release` job runs (tests → npm publish → GitHub Release)
2. New `docker` job runs after `release` succeeds
3. Builds multi-platform image and pushes to `ghcr.io/egulatee/mcp-server-codecov` with tags: `latest`, `2`, `2.1`, `2.1.0`

No new secrets required — `GITHUB_TOKEN` authenticates to GHCR automatically.

## Test plan

- [ ] Merge and push a `v*` tag to trigger the full workflow
- [ ] Confirm `release` job succeeds (npm publish)
- [ ] Confirm `docker` job succeeds and image appears at `ghcr.io/egulatee/mcp-server-codecov`
- [ ] Verify all 4 tags are present (`latest`, major, minor, patch)
- [ ] Set package visibility to **Public** in GitHub → Packages → mcp-server-codecov → Package settings
- [ ] Test locally: `docker run --rm -i -e CODECOV_TOKEN=xxx ghcr.io/egulatee/mcp-server-codecov`

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)