### PR TITLE
feat: add socat to Docker image for stdio-to-TCP bridging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm run build && npm prune --omit=dev
 
 # Stage 2 — runtime (no npm calls, avoids QEMU cross-compilation issues)
 FROM node:20-alpine
+RUN apk add --no-cache socat
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist

--- a/README.md
+++ b/README.md
@@ -310,6 +310,22 @@ docker run --rm -i \
 
 **Available tags:** `latest`, `2`, `2.1`, `2.1.0` (full semver)
 
+**stdio bridge with socat:**
+
+The Docker image includes [`socat`](https://linux.die.net/man/1/socat), which allows MCP clients that communicate over stdio to connect to the server running inside a container via a TCP socket:
+
+```bash
+# Start the server exposing a TCP port
+docker run --rm -p 3000:3000 \
+  -e CODECOV_TOKEN=your_token \
+  ghcr.io/egulatee/mcp-server-codecov
+
+# Bridge stdio ↔ TCP in a second terminal (or from your MCP client config)
+socat TCP:localhost:3000 STDIO
+```
+
+> **Note:** `socat` must also be installed on the **host machine** running the bridge command. Install with `brew install socat` (macOS), `apt install socat` (Debian/Ubuntu), or `apk add socat` (Alpine).
+
 ### Installing from npm Globally
 
 ```bash


### PR DESCRIPTION
## Summary

- Installs `socat` in the Alpine runtime stage of the Docker image so MCP clients can bridge stdio ↔ TCP to a containerized server
- Documents the socat bridge pattern and host-side installation requirements in the Docker section of the README

## Changes

| File | Change |
|---|---|
| `Dockerfile` | `RUN apk add --no-cache socat` added to the runtime stage |
| `README.md` | New **stdio bridge with socat** subsection under the Docker installation guide |

## Test plan

- [ ] Build Docker image locally and verify `socat` binary is present: `docker run --rm ghcr.io/egulatee/mcp-server-codecov socat -V`
- [ ] Confirm existing CI tests still pass (no build regressions)
- [ ] Smoke-test stdio bridge: start container, run `socat TCP:localhost:3000 STDIO`, confirm MCP handshake

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)