### PR TITLE
feat: publish static tool manifest (tools.json) as versioned build artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,22 @@ jobs:
           sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '$d' > release_notes.md
           cat release_notes.md
 
+      - name: Validate tools manifest
+        run: |
+          node -e "
+            const fs = require('fs');
+            const m = JSON.parse(fs.readFileSync('dist/tools.json', 'utf8'));
+            if (!Array.isArray(m.tools) || m.tools.length === 0) { process.exit(1); }
+            console.log('tools.json OK:', m.tools.length, 'tools, v' + m.version);
+          "
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           body_path: release_notes.md
           draft: false
           prerelease: false
+          files: dist/tools.json
 
   docker:
     needs: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,19 @@ jobs:
       - name: Build for integration tests
         run: npm run build
 
+      - name: Validate tools manifest
+        run: |
+          node -e "
+            const fs = require('fs');
+            const m = JSON.parse(fs.readFileSync('dist/tools.json', 'utf8'));
+            if (!m.version) throw new Error('missing version');
+            if (!Array.isArray(m.tools) || m.tools.length === 0) throw new Error('tools array empty or missing');
+            for (const t of m.tools) {
+              if (!t.name || !t.description || !t.inputSchema) throw new Error('malformed tool: ' + t.name);
+            }
+            console.log('tools.json OK:', m.tools.length, 'tools, v' + m.version);
+          "
+
       - name: Run integration tests
         run: npm run test:integration
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache socat
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/dist/tools.json ./tools.json
 COPY package.json ./
 USER node
 ENTRYPOINT ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./tools.json": "./dist/tools.json"
   },
   "bin": {
     "mcp-codecov": "dist/index.js"
@@ -26,7 +27,8 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/generate-tools-manifest.mjs",
+    "generate-manifest": "node scripts/generate-tools-manifest.mjs",
     "watch": "tsc --watch",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run build",

--- a/scripts/generate-tools-manifest.mjs
+++ b/scripts/generate-tools-manifest.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Generates dist/tools.json — a static, versioned snapshot of the MCP tool catalog.
+ *
+ * Run automatically as part of `npm run build`. Consumers that cannot call
+ * `tools/list` at startup (e.g. synchronous plugin hosts like OpenClaw) can
+ * read this file to register tools without making a live MCP request.
+ *
+ * Output shape mirrors the MCP `tools/list` response so no translation layer
+ * is needed:
+ *   {
+ *     "version": "2.2.3",
+ *     "generatedAt": "2026-02-17T00:00:00.000Z",
+ *     "tools": [ { "name": "...", "description": "...", "inputSchema": {...} } ]
+ *   }
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+// Read version from package.json (synchronous, no runtime dep required)
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+
+// Import compiled tool definitions (requires `tsc` to have run first)
+const { TOOLS } = await import('../dist/tools.js');
+
+const manifest = {
+  version: pkg.version,
+  generatedAt: new Date().toISOString(),
+  tools: TOOLS,
+};
+
+const outPath = join(root, 'dist', 'tools.json');
+writeFileSync(outPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+
+console.log(`tools.json written → dist/tools.json (${TOOLS.length} tools, v${pkg.version})`);


### PR DESCRIPTION
## Summary

Resolves #114 — enables synchronous plugin hosts (e.g. OpenClaw's `mcp-bridge` plugin, see [openclaw-operator#23](https://github.com/realestateanalyzorinfra/openclaw-operator/issues/23)) to register codecov tools without a live `tools/list` MCP call at startup.

- **`scripts/generate-tools-manifest.mjs`** — new ESM script that imports `TOOLS` from compiled `dist/tools.js` and writes `dist/tools.json` with `version` + `generatedAt` metadata. Shape mirrors the MCP `tools/list` response; no translation layer needed by consumers.
- **`package.json`** — `build` now runs `tsc && node scripts/generate-tools-manifest.mjs`; adds `generate-manifest` script for standalone runs; adds `"./tools.json": "./dist/tools.json"` export for npm consumers.
- **`Dockerfile`** — copies `dist/tools.json` → `/app/tools.json` in the runtime stage so init containers and sidecars have a well-known path.
- **`release.yml`** — validates manifest after build; attaches `dist/tools.json` as a release asset on every GitHub Release.
- **`test.yml`** — validates manifest structure (version present, tools array non-empty, each tool has `name`/`description`/`inputSchema`) after every CI build.

## Test plan

- [x] `npm run build` succeeds and prints `tools.json written → dist/tools.json (5 tools, v2.2.3)`
- [x] `npm test` — all 80 tests pass
- [x] Manifest structure validated locally (version, tools array, required fields)
- [x] `npm run generate-manifest` works standalone (after a prior build)
- [ ] CI green on PR (test.yml validates manifest on Node 20 + 22)
- [ ] Release workflow attaches `tools.json` as a release asset on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)