### PR TITLE
chore: enable noUncheckedIndexedAccess and exactOptionalPropertyTypes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import { LRUCache } from './cache.js';
  */
 export class CodecovClient {
   private baseUrl: string;
-  private token?: string;
+  private token: string | undefined;
   private cache?: LRUCache<unknown>;
 
   constructor(config: CodecovConfig) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,11 @@ export function getConfig(): CodecovConfig {
   const token = process.env.CODECOV_TOKEN;
   const cache = getCacheConfig();
 
-  return { baseUrl, token, cache };
+  return {
+    baseUrl,
+    ...(token !== undefined ? { token } : {}),
+    cache,
+  };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ function isMainModule(): boolean {
     const currentModulePath = fileURLToPath(import.meta.url);
 
     // Get the real path of the executed script (resolves symlinks)
-    const executedScriptPath = realpathSync(process.argv[1]);
+    const executedScriptPath = realpathSync(process.argv[1] ?? '');
 
     return currentModulePath === executedScriptPath;
   /* istanbul ignore next -- only reachable when realpathSync throws (e.g. broken symlink) */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

Enables two additional TypeScript strictness flags that catch subtle runtime bugs beyond what `strict: true` covers:

- **`noUncheckedIndexedAccess`** — forces handling of `undefined` when indexing arrays/objects, preventing silent crashes from out-of-bounds reads
- **`exactOptionalPropertyTypes`** — distinguishes properties that are absent from those explicitly set to `undefined`, surfacing incorrect assumptions about optional fields

Three type errors were surfaced and fixed:
- `src/client.ts`: Changed `private token?: string` to `private token: string | undefined` to allow explicit assignment
- `src/config.ts`: Conditionally spread `token` in the returned config object instead of always including it (possibly as `undefined`)
- `src/index.ts`: Added `?? ''` fallback for `process.argv[1]` which is now correctly typed as `string | undefined` with `noUncheckedIndexedAccess`

## Test plan

- [x] `npm run build` passes with zero type errors
- [x] All 100 tests pass (`npm test`)

Closes #121